### PR TITLE
ChatGPT 채팅 기능 추가

### DIFF
--- a/src/main/java/toyproject/personal/englishconversation/config/ChatGPTConfig.java
+++ b/src/main/java/toyproject/personal/englishconversation/config/ChatGPTConfig.java
@@ -1,0 +1,24 @@
+package toyproject.personal.englishconversation.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class ChatGPTConfig {
+
+    @Value("${api.key}")
+    private String API_KEY;
+    public static final String URL = "https://api.openai.com/v1/chat/completions";
+
+    @Bean
+    public RestTemplate restTemplate(){
+        return new RestTemplate();
+    }
+
+    public String getApiKey(){
+        return API_KEY;
+    }
+
+}

--- a/src/main/java/toyproject/personal/englishconversation/config/ChatGPTConfig.java
+++ b/src/main/java/toyproject/personal/englishconversation/config/ChatGPTConfig.java
@@ -8,7 +8,7 @@ import org.springframework.web.client.RestTemplate;
 @Configuration
 public class ChatGPTConfig {
 
-    @Value("${api.key}")
+    @Value("${GPT_API_KEY}")
     private String API_KEY;
     public static final String URL = "https://api.openai.com/v1/chat/completions";
 

--- a/src/main/java/toyproject/personal/englishconversation/config/ChatGPTContent.java
+++ b/src/main/java/toyproject/personal/englishconversation/config/ChatGPTContent.java
@@ -8,7 +8,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 @Getter
 @Component
-//@Scope(value = WebApplicationContext.SCOPE_REQUEST, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@Scope(value = WebApplicationContext.SCOPE_REQUEST, proxyMode = ScopedProxyMode.TARGET_CLASS)
 public class ChatGPTContent {
 
     private String Content = """

--- a/src/main/java/toyproject/personal/englishconversation/config/ChatGPTContent.java
+++ b/src/main/java/toyproject/personal/englishconversation/config/ChatGPTContent.java
@@ -1,0 +1,27 @@
+package toyproject.personal.englishconversation.config;
+
+import lombok.Getter;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.WebApplicationContext;
+
+@Getter
+@Component
+//@Scope(value = WebApplicationContext.SCOPE_REQUEST, proxyMode = ScopedProxyMode.TARGET_CLASS)
+public class ChatGPTContent {
+
+    private String Content = """
+            You always ask simple questions in English. Correct me if there is anything wrong or not natural about my response such as grammar, words, idioms, etc. And explain the reason simply in Korean. And when you are done explaining, please continue with the simple reaction and questions about my response again. If there is no my response, you start the question.
+            Your response form always must be in the form of a JSON code
+            {"correctMap":{wrong part:fixed}, "explanation":"content", "message":"content"}
+            if it is our first dialog, JSON code must be {"message":"content"}
+            if there's no wrong part, JSON code must be {"message":"content"}
+            Topic: %s
+            """;
+
+    public void setContent(String topic){
+        Content = Content.formatted(topic);
+    }
+
+}

--- a/src/main/java/toyproject/personal/englishconversation/controller/ChatController.java
+++ b/src/main/java/toyproject/personal/englishconversation/controller/ChatController.java
@@ -24,8 +24,7 @@ public class ChatController {
     @PostMapping
     public ResponseEntity<GPTMessage> chat(@RequestBody ChatGPTRequestDto request) throws IOException {
         log.debug("request: {}", request);
-        GPTMessage gptMessage = chatService.processChatRequest(request);
-        return ResponseEntity.ok(gptMessage);
+        return ResponseEntity.ok(chatService.processChatRequest(request));
     }
 
 }

--- a/src/main/java/toyproject/personal/englishconversation/controller/ChatController.java
+++ b/src/main/java/toyproject/personal/englishconversation/controller/ChatController.java
@@ -1,0 +1,31 @@
+package toyproject.personal.englishconversation.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import toyproject.personal.englishconversation.controller.dto.ChatGPTRequestDto;
+import toyproject.personal.englishconversation.domain.message.GPTMessage;
+import toyproject.personal.englishconversation.service.ChatService;
+
+import java.io.IOException;
+
+@Slf4j
+@Controller
+@RequestMapping("/chat")
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final ChatService chatService;
+
+    @PostMapping
+    public ResponseEntity<GPTMessage> chat(@RequestBody ChatGPTRequestDto request) throws IOException {
+        log.debug("request: {}", request);
+        GPTMessage gptMessage = chatService.processChatRequest(request);
+        return ResponseEntity.ok(gptMessage);
+    }
+
+}

--- a/src/main/java/toyproject/personal/englishconversation/controller/dto/ChatGPTRequestDto.java
+++ b/src/main/java/toyproject/personal/englishconversation/controller/dto/ChatGPTRequestDto.java
@@ -1,0 +1,28 @@
+package toyproject.personal.englishconversation.controller.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.LinkedList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ChatGPTRequestDto {
+
+    /** from client **/
+    @JsonDeserialize(as = LinkedList.class) // LinkedList로 매핑하도록 지정 (Jackson default: ArrayList)
+    private List<Message> messages; // 이전 채팅 내용 포함
+    private String model;
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY) // 역직렬화할 때만 포함하도록 함 (api 요청할 때는 필요 없음)
+    private String topic;
+
+    /** ChatGPTContent 추가 (메시지 세팅) **/
+    public void addContentToMessages(String content){
+        ((LinkedList<Message>) messages).addFirst(new Message("user", content));
+    }
+
+}

--- a/src/main/java/toyproject/personal/englishconversation/controller/dto/ChatGPTRequestDto.java
+++ b/src/main/java/toyproject/personal/englishconversation/controller/dto/ChatGPTRequestDto.java
@@ -3,6 +3,7 @@ package toyproject.personal.englishconversation.controller.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -21,8 +22,14 @@ public class ChatGPTRequestDto {
     private String topic;
 
     /** ChatGPTContent 추가 (메시지 세팅) **/
-    public void addContentToMessages(String content){
+    public void addContentToMessages(String content) {
         ((LinkedList<Message>) messages).addFirst(new Message("user", content));
     }
 
+    @Builder
+    private ChatGPTRequestDto(List<Message> messages, String model, String topic) {
+        this.messages = messages;
+        this.model = model;
+        this.topic = topic;
+    }
 }

--- a/src/main/java/toyproject/personal/englishconversation/controller/dto/ChatGPTResponseDto.java
+++ b/src/main/java/toyproject/personal/englishconversation/controller/dto/ChatGPTResponseDto.java
@@ -1,0 +1,19 @@
+package toyproject.personal.englishconversation.controller.dto;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ChatGPTResponseDto {
+    private List<Choice> choices;
+
+    @Getter
+    public static class Choice { // 내부 클래스는 static 타입이어야 매핑 대상이 됨
+        private Integer index;
+        private Message message;
+    }
+
+}

--- a/src/main/java/toyproject/personal/englishconversation/controller/dto/ChatGPTResponseDto.java
+++ b/src/main/java/toyproject/personal/englishconversation/controller/dto/ChatGPTResponseDto.java
@@ -1,8 +1,7 @@
 package toyproject.personal.englishconversation.controller.dto;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -11,9 +10,18 @@ public class ChatGPTResponseDto {
     private List<Choice> choices;
 
     @Getter
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
     public static class Choice { // 내부 클래스는 static 타입이어야 매핑 대상이 됨
         private Integer index;
         private Message message;
+    }
+
+    @Builder
+    private ChatGPTResponseDto(Integer index, Message message) {
+        Choice choice = new Choice(index, message);
+        this.choices = new ArrayList<>();
+        this.choices.add(choice);
     }
 
 }

--- a/src/main/java/toyproject/personal/englishconversation/controller/dto/Message.java
+++ b/src/main/java/toyproject/personal/englishconversation/controller/dto/Message.java
@@ -1,0 +1,11 @@
+package toyproject.personal.englishconversation.controller.dto;
+
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class Message {
+    private String role;
+    private String content;
+}

--- a/src/main/java/toyproject/personal/englishconversation/domain/message/GPTMessage.java
+++ b/src/main/java/toyproject/personal/englishconversation/domain/message/GPTMessage.java
@@ -1,0 +1,14 @@
+package toyproject.personal.englishconversation.domain.message;
+
+
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class GPTMessage {
+    private String id;
+    private Map<String, String> correctMap;
+    private String explanation;
+    private String message;
+}

--- a/src/main/java/toyproject/personal/englishconversation/domain/message/GPTMessage.java
+++ b/src/main/java/toyproject/personal/englishconversation/domain/message/GPTMessage.java
@@ -1,11 +1,16 @@
 package toyproject.personal.englishconversation.domain.message;
 
 
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.Map;
 
 @Getter
+@Builder // 일부 필드만 초기화 가능
+@EqualsAndHashCode // equals()를 필드 비교 방식으로 구현
 public class GPTMessage {
     private String id;
     private Map<String, String> correctMap;

--- a/src/main/java/toyproject/personal/englishconversation/domain/message/UserMessage.java
+++ b/src/main/java/toyproject/personal/englishconversation/domain/message/UserMessage.java
@@ -1,0 +1,7 @@
+package toyproject.personal.englishconversation.domain.message;
+
+
+public class UserMessage {
+    private String id;
+    private String message;
+}

--- a/src/main/java/toyproject/personal/englishconversation/exception/ChatGPTExceptionHandler.java
+++ b/src/main/java/toyproject/personal/englishconversation/exception/ChatGPTExceptionHandler.java
@@ -1,0 +1,53 @@
+package toyproject.personal.englishconversation.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.client.HttpClientErrorException;
+import toyproject.personal.englishconversation.controller.ChatController;
+
+import java.io.IOException;
+
+@Slf4j
+@RestControllerAdvice(assignableTypes = ChatController.class)
+public class ChatGPTExceptionHandler {
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorResult> HttpClientErrorExceptionHandle(HttpClientErrorException e) {
+        log.error("[HttpClientErrorExceptionHandle] ex", e);
+
+        ErrorResult errorResult = new ErrorResult("EX", "서버 오류");
+
+        if(e.getStatusCode() == HttpStatus.UNAUTHORIZED)
+            errorResult = new ErrorResult("EX", "서버 오류");
+
+        if(e.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS)
+            errorResult = new ErrorResult("EX", "요청 속도 초과");
+
+        if(e.getStatusCode() == HttpStatus.INTERNAL_SERVER_ERROR)
+            errorResult = new ErrorResult("EX", "ChatGPT 서버 오류");
+
+        /** 추후 자동으로 재요청하는 로직 구현 예정 **/
+        if(e.getStatusCode() == HttpStatus.SERVICE_UNAVAILABLE)
+            errorResult = new ErrorResult("EX", "ChatGPT 서버 오류");
+
+        return new ResponseEntity<>(errorResult, HttpStatus.valueOf(e.getRawStatusCode()));
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler
+    public ErrorResult objectMapperExceptionHandle(IOException e){
+        log.error("[objectMapperExceptionHandle] ex", e);
+        return new ErrorResult("EX", "서버 오류");
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler
+    public ErrorResult internalExceptionHandle(Exception e){
+      log.error("[internalExceptionHandle] ex", e);
+      return new ErrorResult("EX", "서버 오류");
+    }
+}

--- a/src/main/java/toyproject/personal/englishconversation/exception/ErrorResult.java
+++ b/src/main/java/toyproject/personal/englishconversation/exception/ErrorResult.java
@@ -1,0 +1,11 @@
+package toyproject.personal.englishconversation.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ErrorResult {
+    private String code;
+    private String message;
+}

--- a/src/main/java/toyproject/personal/englishconversation/service/ChatGPTService.java
+++ b/src/main/java/toyproject/personal/englishconversation/service/ChatGPTService.java
@@ -1,0 +1,68 @@
+package toyproject.personal.englishconversation.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import toyproject.personal.englishconversation.config.ChatGPTConfig;
+import toyproject.personal.englishconversation.config.ChatGPTContent;
+import toyproject.personal.englishconversation.controller.dto.ChatGPTRequestDto;
+import toyproject.personal.englishconversation.controller.dto.ChatGPTResponseDto;
+import toyproject.personal.englishconversation.domain.message.GPTMessage;
+
+import java.io.IOException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatGPTService {
+
+    private final ObjectMapper objectMapper;
+    private final RestTemplate restTemplate;
+    private final ChatGPTConfig chatGPTConfig;
+    private final ChatGPTContent chatGPTContent; // 요청 스코프 빈
+
+    public GPTMessage callChatGPTApi(ChatGPTRequestDto requestDto) throws IOException {
+        HttpEntity<String> entity = prepareRequestEntity(requestDto);
+        ResponseEntity<String> response = executeApiRequest(entity);
+
+        return processResponse(response);
+    }
+
+    /** API 요청 준비 **/
+    private HttpEntity<String> prepareRequestEntity(ChatGPTRequestDto requestDto) throws JsonProcessingException {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("Authorization", "Bearer " + chatGPTConfig.getApiKey());
+
+        setRequestDto(requestDto);
+
+        return new HttpEntity<>(objectMapper.writeValueAsString(requestDto), headers);
+    }
+
+    /** API 요청 **/
+    private ResponseEntity<String> executeApiRequest(HttpEntity<String> entity) {
+        return restTemplate.postForEntity(ChatGPTConfig.URL, entity, String.class);
+    }
+
+    /** GPT 응답 처리 **/
+    private GPTMessage processResponse(ResponseEntity<String> response) throws JsonProcessingException {
+        ChatGPTResponseDto responseDto = objectMapper.readValue(response.getBody(), ChatGPTResponseDto.class);
+        String contentJson = responseDto.getChoices().get(0).getMessage().getContent();
+
+        return objectMapper.readValue(contentJson, GPTMessage.class);
+    }
+
+    /** API 요청 전 메시지 세팅 **/
+    private void setRequestDto(ChatGPTRequestDto requestDto) {
+        chatGPTContent.setContent(requestDto.getTopic());
+        requestDto.addContentToMessages(chatGPTContent.getContent());
+    }
+
+}

--- a/src/main/java/toyproject/personal/englishconversation/service/ChatService.java
+++ b/src/main/java/toyproject/personal/englishconversation/service/ChatService.java
@@ -1,0 +1,21 @@
+package toyproject.personal.englishconversation.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import toyproject.personal.englishconversation.controller.dto.ChatGPTRequestDto;
+import toyproject.personal.englishconversation.domain.message.GPTMessage;
+
+import java.io.IOException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+    private final ChatGPTService chatGPTService;
+
+    public GPTMessage processChatRequest(ChatGPTRequestDto requestDto) throws IOException {
+        return chatGPTService.callChatGPTApi(requestDto);
+    }
+}

--- a/src/test/java/toyproject/personal/englishconversation/controller/ChatControllerTest.java
+++ b/src/test/java/toyproject/personal/englishconversation/controller/ChatControllerTest.java
@@ -1,0 +1,58 @@
+package toyproject.personal.englishconversation.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import toyproject.personal.englishconversation.controller.dto.ChatGPTRequestDto;
+import toyproject.personal.englishconversation.domain.message.GPTMessage;
+import toyproject.personal.englishconversation.service.ChatService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = ChatController.class)
+class ChatControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ChatService chatService;
+
+    private Map<String, String> getCorrectMap() {
+        Map<String, String> correctMap = new HashMap<>();
+        correctMap.put("wrong sentence", "correct sentence");
+        return correctMap;
+    }
+
+    @Test
+    void chat() throws Exception {
+        // Given
+        GPTMessage gptMessage = GPTMessage.builder()
+                .id("1")
+                .correctMap(getCorrectMap())
+                .explanation("explanation")
+                .message("message")
+                .build();
+        given(chatService.processChatRequest(any(ChatGPTRequestDto.class))).willReturn(gptMessage);
+
+        // WhenThen
+        mockMvc.perform(post("/chat")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value("1"))
+                .andExpect(jsonPath("$.explanation").value("explanation"))
+                .andExpect(jsonPath("$.message").value("message"))
+                .andExpect(jsonPath("$.correctMap['wrong sentence']").value("correct sentence"));
+    }
+
+}

--- a/src/test/java/toyproject/personal/englishconversation/exception/ChatGPTExceptionHandlerTest.java
+++ b/src/test/java/toyproject/personal/englishconversation/exception/ChatGPTExceptionHandlerTest.java
@@ -1,0 +1,82 @@
+package toyproject.personal.englishconversation.exception;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.client.HttpClientErrorException;
+import toyproject.personal.englishconversation.controller.dto.ChatGPTRequestDto;
+import toyproject.personal.englishconversation.service.ChatService;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class ChatGPTExceptionHandlerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ChatService chatService;
+
+
+    /** ChatGPT API 응답 상태코드에 따른 테스트 **/
+    @ParameterizedTest
+    @MethodSource("httpStatusProvider")
+    public void HttpClientErrorExceptionHandle(HttpStatus status, String expectedCode, String expectedMessage) throws Exception {
+        // Given
+        HttpClientErrorException exception = new HttpClientErrorException(status, expectedMessage);
+        Mockito.when(chatService.processChatRequest(any(ChatGPTRequestDto.class)))
+                .thenThrow(exception);
+
+        // WhenThen
+        mockMvc.perform(post("/chat")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().is(status.value()))
+                .andExpect(jsonPath("$.code").value(expectedCode))
+                .andExpect(jsonPath("$.message").value(expectedMessage));
+    }
+
+    /** ChatGPT API 응답 상태 코드 종류 **/
+    static Stream<Arguments> httpStatusProvider() {
+        return Stream.of(
+                Arguments.of(HttpStatus.UNAUTHORIZED, "EX", "서버 오류"),
+                Arguments.of(HttpStatus.TOO_MANY_REQUESTS, "EX", "요청 속도 초과"),
+                Arguments.of(HttpStatus.INTERNAL_SERVER_ERROR, "EX", "ChatGPT 서버 오류"),
+                Arguments.of(HttpStatus.SERVICE_UNAVAILABLE, "EX", "ChatGPT 서버 오류")
+        );
+    }
+
+    @Test
+    public void objectMapperExceptionHandle() throws Exception {
+        // Given
+        given(chatService.processChatRequest(any(ChatGPTRequestDto.class)))
+                .willThrow(new IOException());
+
+        // WhenThen
+        mockMvc.perform(post("/chat")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("")) // 잘못된 Json 형식 -> Json 매핑 실패
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.code").value("EX"))
+                .andExpect(jsonPath("$.message").value("서버 오류"));
+    }
+
+}

--- a/src/test/java/toyproject/personal/englishconversation/service/ChatGPTServiceTest.java
+++ b/src/test/java/toyproject/personal/englishconversation/service/ChatGPTServiceTest.java
@@ -1,0 +1,113 @@
+package toyproject.personal.englishconversation.service;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.web.client.RestTemplate;
+import toyproject.personal.englishconversation.config.ChatGPTConfig;
+import toyproject.personal.englishconversation.config.ChatGPTContent;
+import toyproject.personal.englishconversation.controller.dto.ChatGPTRequestDto;
+import toyproject.personal.englishconversation.controller.dto.ChatGPTResponseDto;
+import toyproject.personal.englishconversation.controller.dto.Message;
+import toyproject.personal.englishconversation.domain.message.GPTMessage;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+class ChatGPTServiceTest {
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private ChatGPTConfig chatGPTConfig;
+
+    @Mock
+    private ChatGPTContent chatGPTContent;
+
+    @InjectMocks
+    private ChatGPTService chatGPTService;
+
+    private Message getMessage(){
+        return new Message("assistant", "message");
+    }
+
+    private List<Message> getMessages(){
+        List<Message> messages = new LinkedList<>();
+        messages.add(new Message("user", "message"));
+        return messages;
+    }
+
+    private ChatGPTRequestDto getChatGPTRequestDto() {
+        ChatGPTRequestDto requestDto = ChatGPTRequestDto.builder()
+                .messages(getMessages())
+                .model("gpt4")
+                .topic("topic")
+                .build();
+
+        // ChatGPTContent (기본설정) 추가
+        ChatGPTContent chatGPTContent = new ChatGPTContent();
+        chatGPTContent.setContent(requestDto.getTopic());
+        requestDto.addContentToMessages(chatGPTContent.getContent());
+
+        return requestDto;
+    }
+
+    private ChatGPTResponseDto getChatGPTResponseDto(){
+        return ChatGPTResponseDto.builder()
+                .index(1)
+                .message(getMessage())
+                .build();
+    }
+
+    private Map<String, String> getCorrectMap() {
+        Map<String, String> correctMap = new HashMap<>();
+        correctMap.put("wrong sentence", "correct sentence");
+        return correctMap;
+    }
+
+    private GPTMessage getGPTMessage() {
+        return GPTMessage.builder()
+                .id("1")
+                .correctMap(getCorrectMap())
+                .explanation("explanation")
+                .message("message")
+                .build();
+    }
+
+    @Test
+    public void callChatGPTApiTest() throws Exception {
+        // Given
+        GPTMessage gptMessage = getGPTMessage();
+        given(chatGPTConfig.getApiKey()).willReturn("test_api_key");
+        given(chatGPTContent.getContent()).willReturn("test content");
+        given(restTemplate.postForEntity(any(String.class), any(HttpEntity.class), any(Class.class)))
+                .willReturn(new ResponseEntity<>("responseBody", HttpStatus.OK));
+        given(objectMapper.readValue(any(String.class), eq(ChatGPTResponseDto.class)))
+                .willReturn(getChatGPTResponseDto());
+        given(objectMapper.readValue(any(String.class), eq(GPTMessage.class)))
+                .willReturn(getGPTMessage());
+        given(objectMapper.writeValueAsString(any(ChatGPTRequestDto.class))).willReturn("expected json");
+
+        // When
+        GPTMessage result = chatGPTService.callChatGPTApi(getChatGPTRequestDto());
+
+        // Then
+        assertThat(gptMessage).isEqualTo(result);
+    }
+}

--- a/src/test/java/toyproject/personal/englishconversation/service/ChatServiceTest.java
+++ b/src/test/java/toyproject/personal/englishconversation/service/ChatServiceTest.java
@@ -1,0 +1,81 @@
+package toyproject.personal.englishconversation.service;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+import toyproject.personal.englishconversation.config.ChatGPTContent;
+import toyproject.personal.englishconversation.controller.dto.ChatGPTRequestDto;
+import toyproject.personal.englishconversation.controller.dto.Message;
+import toyproject.personal.englishconversation.domain.message.GPTMessage;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+class ChatServiceTest {
+
+    @Mock
+    private ChatGPTService chatGPTService;
+
+    @InjectMocks
+    private ChatService chatService;
+
+    private List<Message> getMessages(){
+        List<Message> messages = new LinkedList<>();
+        messages.add(new Message("user", "message"));
+        return messages;
+    }
+
+    private Map<String, String> getCorrectMap() {
+        Map<String, String> correctMap = new HashMap<>();
+        correctMap.put("wrong sentence", "correct sentence");
+        return correctMap;
+    }
+
+    private ChatGPTRequestDto getChatGPTRequestDto() {
+        ChatGPTRequestDto requestDto = ChatGPTRequestDto.builder()
+                .messages(getMessages())
+                .model("gpt4")
+                .topic("topic")
+                .build();
+
+        // ChatGPTContent (기본설정) 추가
+        ChatGPTContent chatGPTContent = new ChatGPTContent();
+        chatGPTContent.setContent(requestDto.getTopic());
+        requestDto.addContentToMessages(chatGPTContent.getContent());
+
+        return requestDto;
+    }
+
+    private GPTMessage getGPTMessage() {
+        return GPTMessage.builder()
+                .id("1")
+                .correctMap(getCorrectMap())
+                .explanation("explanation")
+                .message("message")
+                .build();
+    }
+
+    @Test
+    void processChatRequest() throws IOException {
+        // Given
+        GPTMessage gptMessage = getGPTMessage();
+        ChatGPTRequestDto chatGPTRequestDto = getChatGPTRequestDto();
+        given(chatGPTService.callChatGPTApi(chatGPTRequestDto)).willReturn(getGPTMessage());
+
+        // When
+        GPTMessage result = chatService.processChatRequest(chatGPTRequestDto);
+
+        // Then
+        assertThat(gptMessage).isEqualTo(result);
+        verify(chatGPTService).callChatGPTApi(chatGPTRequestDto);
+    }
+}


### PR DESCRIPTION
## 목적
> ChatGPT 채팅 기능 추가

## 작업 상세 내용
- [ ] ChatGPT API 요청 및 응답 코드 작성
- [ ] API 호출 관련 예외처리
- [ ] 단위 테스트 코드 작성 (Controller, Service, ExceptionHandler)